### PR TITLE
Switch from SEND_KEY to RUN_COMMAND for some gestures

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
 # ToucheggKDE
 TouchEgg configuration for Touchpad Gestures like MacOS/Windows for KDE Plasma. Finally, enjoy the multi-touch touchpad gesture goodness of MacOS in KDE Plasma!
 
-## Requirements
-1. Go to `System Settings` -> `Shortcuts` -> `Global Shortcuts` -> `Audio Volume`
-2. Set `Decrease Volume` Shortcut to `Alt+[` and `Increase Volume` Shortcut to `Alt+]`
-
 ## Installation
 [Install touchegg first if you haven't already](https://github.com/JoseExposito/touchegg)   
 $ `git clone https://github.com/NayamAmarshe/ToucheggKDE.git`   

--- a/touchegg.conf
+++ b/touchegg.conf
@@ -41,10 +41,9 @@
   -->
   <application name="All">
     <gesture type="SWIPE" fingers="3" direction="UP">   
-        <action type="SEND_KEYS">
+        <action type="RUN_COMMAND">
             <repeat>false</repeat>
-            <modifiers>Control_L</modifiers>
-            <keys>F9</keys>
+            <command>qdbus org.kde.kglobalaccel /component/kwin invokeShortcut 'Expose'</command>
             <on>begin</on>
         </action>
     </gesture>
@@ -76,37 +75,35 @@
     </gesture>
 
     <gesture type="PINCH" fingers="3" direction="IN">
-      <action type="SEND_KEYS">
+      <action type="RUN_COMMAND">
         <repeat>false</repeat>
-        <modifiers>Control_L</modifiers>
-        <keys>F8</keys>
+        <command>qdbus org.kde.kglobalaccel /component/kwin invokeShortcut 'ShowDesktopGrid'</command>
         <on>begin</on>
       </action>
     </gesture>
 
     <gesture type="PINCH" fingers="3" direction="OUT">
-      <action type="SEND_KEYS">
+      <action type="RUN_COMMAND">
         <repeat>false</repeat>
-        <modifiers>Control_L</modifiers>
-        <keys>F8</keys>
+        <command>qdbus org.kde.kglobalaccel /component/kwin invokeShortcut 'ShowDesktopGrid'</command>
         <on>begin</on>
       </action>
     </gesture>
     
     <gesture type="SWIPE" fingers="4" direction="UP">
-      <action type="SEND_KEYS">
+      <action type="RUN_COMMAND">
         <repeat>true</repeat>
-        <modifiers>Alt_L</modifiers>
-        <keys>bracketright</keys>
+        <command>qdbus org.kde.kglobalaccel /component/kmix invokeShortcut 'increase_volume'</command>
+        <decreaseCommand>qdbus org.kde.kglobalaccel /component/kmix invokeShortcut 'decrease_volume'</decreaseCommand>
         <on>begin</on>
       </action>
     </gesture>
 
     <gesture type="SWIPE" fingers="4" direction="DOWN">
-      <action type="SEND_KEYS">
+     <action type="RUN_COMMAND">
         <repeat>true</repeat>
-        <modifiers>Alt_L</modifiers>
-        <keys>bracketleft</keys>
+        <command>qdbus org.kde.kglobalaccel /component/kmix invokeShortcut 'decrease_volume'</command>
+        <decreaseCommand>qdbus org.kde.kglobalaccel /component/kmix invokeShortcut 'increase_volume'</decreaseCommand>
         <on>begin</on>
       </action>
     </gesture>


### PR DESCRIPTION
I don't use touchegg at the moment so I haven't tested these however I wanted to share a way to run actions without sending keypresses. This allows users to not worry about having different keybinds and removes the need to add a shortcut for volume control.

To find more invokable shortcuts you can run the following:
`qdbus org.kde.kglobalaccel /component/<componentName> shortcutNames`