### PR TITLE
Fix for QT 6 and openSUSE

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,18 @@ cp touch* ~/.config/touchegg/
 
 ## Troubleshoot
 If you're using OpenSUSE or other distros which don't have the `qdbus` package,
-do this:
+do this for QT 6:
+
+(After installation)
+1. Open `~/.config/touchegg/touchegg.conf`
+2. Search for `qdbus` and replace all occurances with `qdbus6`
+3. Save the file
+
+Or for QT 5:
 ```shell
 nano ~/.bashrc
 ````
-Then at the end of the file, add: `alias qdbus=”qdbus-qt5”`   
+Then at the end of the file, add: `alias qdbus=qdbus-qt5`   
 Exit with Ctrl+O, Enter then Ctrl+X..
 Then
 ```shell


### PR DESCRIPTION
The script wasn't working on openSUSE with QT 6 and Plasma 6.
I found out that the command for qdbus changed to `qdbus6` so I changed the alias according to the troubleshooting section.
But then I ran into the next problem. When installing Touchégg as stated in their README, Touchégg will be executed by the root user, not by the user who edits the aliases for their own bash. (I don't even know if the old fix works because it should be the same thing with QT 5)
So I think it will be the easiest solution to just replace the commands manually. Or maybe you have another idea.